### PR TITLE
Remove team heading text

### DIFF
--- a/app/routes/team.tsx
+++ b/app/routes/team.tsx
@@ -191,9 +191,9 @@ export default function Team() {
               key={team}
               className="mx-auto max-w-3xl px-8 sm:px-6 lg:max-w-9xl lg:px-12"
             >
-              <p className="mb-4 text-left text-2xl font-bold text-night-900 sm:mt-0 sm:text-4xl md:mb-8">
+              {/* <p className="mb-4 text-center text-2xl font-bold text-night-900 sm:mt-0 sm:text-4xl md:mb-8">
                 {team}
-              </p>
+              </p> */}
               <div className="grid grid-cols-2 gap-4 md:grid-cols-3 md:gap-4 lg:grid-cols-5">
                 {members.map((member) => (
                   <TeamCard key={member.name} member={member} />


### PR DESCRIPTION
Gets rid of this heading
<img width="1542" alt="image" src="https://github.com/user-attachments/assets/526614bb-d8f3-4eef-8a5b-3188d1d0aa0f">
